### PR TITLE
Correct message error when no transaction exists

### DIFF
--- a/modules/bitpay/bitpay.php
+++ b/modules/bitpay/bitpay.php
@@ -351,8 +351,16 @@ class bitpay extends PaymentModule {
 
     public function readBitcoinpaymentdetails($id_order) {
       $db = Db::getInstance();
+      $result = array();
       $result = $db->ExecuteS('SELECT * FROM `' . _DB_PREFIX_ . 'order_bitcoin` WHERE `id_order` = ' . intval($id_order) . ';');
-      return $result[0];
+
+      if (count($result)>0) {
+        return $result[0];
+      } else {
+        // $result can be empty
+        return array();
+      }
+      
     }
 
     public function hookInvoice($params) {

--- a/modules/bitpay/bitpay.php
+++ b/modules/bitpay/bitpay.php
@@ -358,7 +358,7 @@ class bitpay extends PaymentModule {
         return $result[0];
       } else {
         // $result can be empty
-        return array();
+        return array( 'invoice_id' => 0, 'status' =>'null');
       }
       
     }


### PR DESCRIPTION
This is a boundary check. $result can be null therefore it must
be checked before returning its value.